### PR TITLE
removed common_msgs depency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -31,9 +31,6 @@
   <build_depend>actionlib_msgs</build_depend>
   <run_depend>actionlib_msgs</run_depend>
 
-  <build_depend>common_msgs</build_depend>
-  <run_depend>common_msgs</run_depend>
-
   <build_depend>visualization_msgs</build_depend>
   <run_depend>visualization_msgs</run_depend>
 


### PR DESCRIPTION
since depending on metapackages is deprecated and all needed subpackages are included anyways
