### PR TITLE
Make the minimum size of a frontier configurable

### DIFF
--- a/include/frontier_exploration/bounded_explore_layer.h
+++ b/include/frontier_exploration/bounded_explore_layer.h
@@ -110,7 +110,7 @@ private:
 
     std::string frontier_travel_point_;
     bool resize_to_boundary_;
-
+    int min_frontier_size_;
 };
 
 }

--- a/include/frontier_exploration/frontier_search.h
+++ b/include/frontier_exploration/frontier_search.h
@@ -16,8 +16,9 @@ public:
     /**
      * @brief Constructor for search task
      * @param costmap Reference to costmap data to search.
+     * @param min_frontier_size The minimum size to accept a frontier
      */
-    FrontierSearch(costmap_2d::Costmap2D& costmap);
+    FrontierSearch(costmap_2d::Costmap2D& costmap, int min_frontier_size);
 
     /**
      * @brief Runs search implementation, outward from the start position
@@ -50,6 +51,7 @@ private:
     costmap_2d::Costmap2D& costmap_;
     unsigned char* map_;
     unsigned int size_x_ , size_y_;
+    int min_frontier_size_;
 
 };
 

--- a/plugins/bounded_explore_layer.cpp
+++ b/plugins/bounded_explore_layer.cpp
@@ -53,6 +53,7 @@ namespace frontier_exploration
 
         nh_.param<bool>("resize_to_boundary", resize_to_boundary_, true);
         nh_.param<std::string>("frontier_travel_point", frontier_travel_point_, "closest");
+        nh_.param<int>("min_frontier_size", min_frontier_size_, 1);
 
         polygonService_ = nh_.advertiseService("update_boundary_polygon", &BoundedExploreLayer::updateBoundaryPolygonService, this);
         frontierService_ = nh_.advertiseService("get_next_frontier", &BoundedExploreLayer::getNextFrontierService, this);
@@ -100,7 +101,7 @@ namespace frontier_exploration
         }
 
         //initialize frontier search implementation
-        FrontierSearch frontierSearch(*(layered_costmap_->getCostmap()));
+        FrontierSearch frontierSearch(*(layered_costmap_->getCostmap()), min_frontier_size_);
         //get list of frontiers from search implementation
         std::list<Frontier> frontier_list = frontierSearch.searchFrom(start_pose.pose.position);
 

--- a/src/frontier_search.cpp
+++ b/src/frontier_search.cpp
@@ -14,7 +14,8 @@ using costmap_2d::LETHAL_OBSTACLE;
 using costmap_2d::NO_INFORMATION;
 using costmap_2d::FREE_SPACE;
 
-FrontierSearch::FrontierSearch(costmap_2d::Costmap2D &costmap) : costmap_(costmap) { }
+FrontierSearch::FrontierSearch(costmap_2d::Costmap2D &costmap, int min_frontier_size) :
+    costmap_(costmap), min_frontier_size_(min_frontier_size) { }
 
 std::list<Frontier> FrontierSearch::searchFrom(geometry_msgs::Point position){
 
@@ -65,7 +66,7 @@ std::list<Frontier> FrontierSearch::searchFrom(geometry_msgs::Point position){
             }else if(isNewFrontierCell(nbr, frontier_flag)){
                 frontier_flag[nbr] = true;
                 Frontier new_frontier = buildNewFrontier(nbr, pos, frontier_flag);
-                if(new_frontier.size > 1){
+                if(new_frontier.size > min_frontier_size_){
                     frontier_list.push_back(new_frontier);
                 }
             }


### PR DESCRIPTION
### Problem

When exploring an unknown space, the minimum required size of a frontier to be explored is one pixel. For my application this is too restrictive: the minimum must either be zero or another number depending on my run configuration.

### Solution 

Add a new parameter (`min_frontier_size`) which allows setting the value of the minimum frontier size. This solution is backwards compatible because the default value is `1`.

---

Documentation should be added on the ROS page for this parameter.