### PR TITLE
Frontier blacklist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ add_service_files(
   FILES
   UpdateBoundaryPolygon.srv
   GetNextFrontier.srv
+  BlacklistPoint.srv
 )
 
 add_action_files(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   roscpp
   std_msgs
+  std_srvs
   tf
   actionlib
   actionlib_msgs

--- a/include/frontier_exploration/bounded_explore_layer.h
+++ b/include/frontier_exploration/bounded_explore_layer.h
@@ -115,6 +115,7 @@ private:
     tf::TransformListener tf_listener_;
 
     ros::Publisher frontier_cloud_pub;
+    ros::Publisher blacklist_marker_pub_;
 
     bool configured_, marked_;
 

--- a/include/frontier_exploration/bounded_explore_layer.h
+++ b/include/frontier_exploration/bounded_explore_layer.h
@@ -117,7 +117,9 @@ private:
     ros::Publisher frontier_cloud_pub;
 
     bool configured_, marked_;
-
+    
+    std::list<geometry_msgs::Point> blacklist_;
+    
     std::string frontier_travel_point_;
     bool resize_to_boundary_;
     int min_frontier_size_;

--- a/include/frontier_exploration/bounded_explore_layer.h
+++ b/include/frontier_exploration/bounded_explore_layer.h
@@ -90,10 +90,20 @@ protected:
      */
     bool getNextFrontier(geometry_msgs::PoseStamped start_pose, geometry_msgs::PoseStamped &next_frontier);
 
-    // TODO: comment
+    /**
+     * @brief ROS Service wrapper for adding a point to the frontier blacklist
+     * @param req Service request
+     * @param res Service response
+     * @return Always true
+     */
     bool blacklistPointService(frontier_exploration::BlacklistPoint::Request &req, frontier_exploration::BlacklistPoint::Response &res);
 
-    // TODO: comment
+    /**
+     * @brief ROS Service wrapper for clearing the frontier blacklist
+     * @param req Service request
+     * @param res Service response
+     * @return Always true
+     */
     bool clearBlacklistService(std_srvs::Empty::Request &req, std_srvs::Empty::Response &resp);
 
 private:

--- a/include/frontier_exploration/bounded_explore_layer.h
+++ b/include/frontier_exploration/bounded_explore_layer.h
@@ -117,12 +117,14 @@ private:
     ros::Publisher frontier_cloud_pub;
 
     bool configured_, marked_;
-    
+
     std::list<geometry_msgs::Point> blacklist_;
-    
+
+    std::string global_frame_;
     std::string frontier_travel_point_;
     bool resize_to_boundary_;
     int min_frontier_size_;
+    double blacklist_radius_;
 };
 
 }

--- a/include/frontier_exploration/bounded_explore_layer.h
+++ b/include/frontier_exploration/bounded_explore_layer.h
@@ -56,6 +56,11 @@ public:
      * @brief Reset exploration progress
      */
     virtual void reset();
+    
+    /**
+     * @brief Future define for visualization_msgs::Marker::DELETEALL. Constant is not defined in ROS Indigo, but functionality is implemented
+     */
+    static const int DELETEALL = 3;
 
 protected:
 

--- a/include/frontier_exploration/bounded_explore_layer.h
+++ b/include/frontier_exploration/bounded_explore_layer.h
@@ -7,9 +7,11 @@
 #include <dynamic_reconfigure/server.h>
 
 #include <geometry_msgs/Polygon.h>
+#include <std_srvs/Empty.h>
 #include <frontier_exploration/Frontier.h>
 #include <frontier_exploration/UpdateBoundaryPolygon.h>
 #include <frontier_exploration/GetNextFrontier.h>
+#include <frontier_exploration/BlacklistPoint.h>
 
 namespace frontier_exploration
 {
@@ -88,6 +90,12 @@ protected:
      */
     bool getNextFrontier(geometry_msgs::PoseStamped start_pose, geometry_msgs::PoseStamped &next_frontier);
 
+    // TODO: comment
+    bool blacklistPointService(frontier_exploration::BlacklistPoint::Request &req, frontier_exploration::BlacklistPoint::Response &res);
+
+    // TODO: comment
+    bool clearBlacklistService(std_srvs::Empty::Request &req, std_srvs::Empty::Response &resp);
+
 private:
 
     /**
@@ -101,6 +109,8 @@ private:
     dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig> *dsrv_;
     ros::ServiceServer polygonService_;
     ros::ServiceServer frontierService_;
+    ros::ServiceServer blacklistPointService_;
+    ros::ServiceServer clearBlacklistService_;
     geometry_msgs::Polygon polygon_;
     tf::TransformListener tf_listener_;
 

--- a/include/frontier_exploration/frontier_search.h
+++ b/include/frontier_exploration/frontier_search.h
@@ -17,8 +17,9 @@ public:
      * @brief Constructor for search task
      * @param costmap Reference to costmap data to search.
      * @param min_frontier_size The minimum size to accept a frontier
+     * @param travel_point The requested travel point (closest|middle|centroid)
      */
-    FrontierSearch(costmap_2d::Costmap2D& costmap, int min_frontier_size);
+    FrontierSearch(costmap_2d::Costmap2D& costmap, int min_frontier_size, std::string &travel_point);
 
     /**
      * @brief Runs search implementation, outward from the start position
@@ -52,6 +53,7 @@ private:
     unsigned char* map_;
     unsigned int size_x_ , size_y_;
     int min_frontier_size_;
+    std::string travel_point_;
 
 };
 

--- a/include/frontier_exploration/geometry_tools.h
+++ b/include/frontier_exploration/geometry_tools.h
@@ -1,6 +1,8 @@
 #ifndef GEOMETRY_TOOLS_H_
 #define GEOMETRY_TOOLS_H_
 
+#include <boost/foreach.hpp>
+
 #include <geometry_msgs/Polygon.h>
 #include <geometry_msgs/Point.h>
 #include <costmap_2d/costmap_2d.h>
@@ -46,6 +48,23 @@ namespace frontier_exploration{
   template<typename T, typename S>
   bool pointsNearby(const T &one, const S &two, const double &proximity){
       return pointsDistance(one, two) <= proximity;
+  }
+  
+  /**
+  * @brief Evaluate whether a point is approximately adjacent, within a specified proximity distance, to any point in a list.
+  * @param one Point one
+  * @param list List<Point> list
+  * @param proximity Proximity distance
+  * @return True if approximately adjacent, false otherwise
+  */
+  template<typename T, typename S>
+  bool anyPointsNearby(const T &one, const std::list<S> &list, const double &proximity){
+      BOOST_FOREACH(S two, list){
+          if (pointsNearby(one, two, proximity)) {
+              return true;
+          }
+      }
+      return false;
   }
 
 /**

--- a/msg/Frontier.msg
+++ b/msg/Frontier.msg
@@ -1,5 +1,3 @@
 uint32 size
 float64 min_distance
-geometry_msgs/Point initial
-geometry_msgs/Point centroid
-geometry_msgs/Point middle
+geometry_msgs/Point travel_point

--- a/package.xml
+++ b/package.xml
@@ -19,12 +19,14 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
   <build_depend>tf</build_depend>
   <run_depend>costmap_2d</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>std_srvs</run_depend>
   <run_depend>tf</run_depend>
 
   <build_depend>message_generation</build_depend>

--- a/plugins/bounded_explore_layer.cpp
+++ b/plugins/bounded_explore_layer.cpp
@@ -44,10 +44,6 @@ namespace frontier_exploration
         configured_ = false;
         marked_ = false;
 
-        // TODO!
-        blacklist_radius_ = 1.5;
-        global_frame_ = "map";
-
         bool explore_clear_space;
         nh_.param("explore_clear_space", explore_clear_space, true);
         if(explore_clear_space){
@@ -307,7 +303,7 @@ namespace frontier_exploration
         // Add point to blacklist
         blacklist_.push_back(req.point);
         ROS_WARN("Blacklist point added %f, %f", req.point.x, req.point.y);
-        
+
         // Show point in blacklist topic
         visualization_msgs::Marker marker;
         marker.type = visualization_msgs::Marker::CYLINDER;
@@ -317,21 +313,21 @@ namespace frontier_exploration
 
         marker.header.frame_id = global_frame_;
         marker.header.stamp = ros::Time::now();
-        
+
         marker.pose.position = req.point;
         marker.pose.orientation.w = 1.0;
-        
+
         // Scale is the diameter of the shape
         marker.scale.x = 2 * blacklist_radius_;
         marker.scale.y = 2 * blacklist_radius_;
         // Circle
         marker.scale.z = 0.05;
-        
+
         marker.color.r = 1.0;
         marker.color.a = 0.6;
-        
+
         blacklist_marker_pub_.publish(marker);
-        
+
         // All is good :)
         return true;
     }
@@ -340,13 +336,13 @@ namespace frontier_exploration
         // Clear the list
         blacklist_.clear();
         ROS_WARN("Blacklist cleared");
-        
+
         // Delete all markers from visualization
         visualization_msgs::Marker marker;
         marker.type = visualization_msgs::Marker::CYLINDER;
         marker.ns = "blacklist";
         marker.action = visualization_msgs::Marker::DELETEALL;
-        
+
         // All is good :)
         return true;
     }

--- a/plugins/bounded_explore_layer.cpp
+++ b/plugins/bounded_explore_layer.cpp
@@ -123,8 +123,7 @@ namespace frontier_exploration
         int max;
         
         // TODO!
-        std::list<geometry_msgs::Point> blacklist;
-        double blacklistRadius = 0.0;
+        double blacklistRadius = 1.5;
         
         BOOST_FOREACH(Frontier frontier, frontier_list){
             //load frontier into visualization poitncloud
@@ -133,7 +132,7 @@ namespace frontier_exploration
             frontier_cloud_viz.push_back(frontier_point_viz);
 
             //check if this frontier is the nearest to robot
-            if (frontier.min_distance < selected.min_distance && !anyPointsNearby(frontier.initial, blacklist, blacklistRadius)){
+            if (frontier.min_distance < selected.min_distance && !anyPointsNearby(frontier.initial, blacklist_, blacklistRadius)){
                 selected = frontier;
                 max = frontier_cloud_viz.size()-1;
             }
@@ -312,11 +311,13 @@ namespace frontier_exploration
     }
 
     bool BoundedExploreLayer::blacklistPointService(frontier_exploration::BlacklistPoint::Request &req, frontier_exploration::BlacklistPoint::Response &res) {
+        blacklist_.push_back(req.point);
         ROS_WARN("Blacklist point added %f, %f", req.point.x, req.point.y);
         return true;
     }
 
     bool BoundedExploreLayer::clearBlacklistService(std_srvs::Empty::Request &req, std_srvs::Empty::Response &resp) {
+        blacklist_.clear();
         ROS_WARN("Blacklist cleared");
         return true;
     }

--- a/plugins/bounded_explore_layer.cpp
+++ b/plugins/bounded_explore_layer.cpp
@@ -341,7 +341,8 @@ namespace frontier_exploration
         visualization_msgs::Marker marker;
         marker.type = visualization_msgs::Marker::CYLINDER;
         marker.ns = "blacklist";
-        marker.action = visualization_msgs::Marker::DELETEALL;
+        // The constant does not exist in ROS Indigo, although functionality is implemented. We use our own.
+        marker.action = DELETEALL;
 
         // All is good :)
         return true;

--- a/src/explore_server.cpp
+++ b/src/explore_server.cpp
@@ -245,19 +245,27 @@ private:
         if (state == actionlib::SimpleClientGoalState::ABORTED){
             ROS_ERROR("Failed to move. Blacklisting point.");
             moving_ = false;
-            // as_.setAborted();
-
+            
+            // Find the blacklist service
             ros::ServiceClient blacklistPointService = private_nh_.serviceClient<BlacklistPoint>("explore_costmap/explore_boundary/blacklist_point");
+            // Create the service request
             BlacklistPoint srv;
             srv.request.point = feedback_.next_frontier.pose.position;
+            
+            // Call the service
             if (!blacklistPointService.call(srv)) {
                 ROS_ERROR("Failed to blacklist point.");
             }
         }else if(state == actionlib::SimpleClientGoalState::SUCCEEDED){
             moving_ = false;
             
+            // Find the clear blacklist service
             ros::ServiceClient clearBlacklistService = private_nh_.serviceClient<std_srvs::Empty>("explore_costmap/explore_boundary/clear_blacklist");
+            
+            // No argument
             std_srvs::Empty srv;
+            
+            // Call the service
             if (!clearBlacklistService.call(srv)) {
                 ROS_ERROR("Failed to clear blacklist.");
             }

--- a/srv/BlacklistPoint.srv
+++ b/srv/BlacklistPoint.srv
@@ -1,0 +1,2 @@
+geometry_msgs/Point point
+---


### PR DESCRIPTION

### Use case 

Exploration of an unknown area. There are many different locations with frontiers. After a while a frontier is chosen but it is momentarily blocked by an obstacle. `move_base` cannot find a valid path. `frontier_exploration` is notified of the movement failure and aborts all exploration.

### Problem

In case of movement failure all exploration is aborted, even though other explorable frontiers might still be available.

### Solution

I have solved this problem by implementing a *blacklist* of points, and a blacklist radius. The points describe the center of circles with the defined radius, together forming a blocked area where no frontiers may be chosen for exploration.

The blacklist is cleared once a frontier has been reached successfully. This allows returning to previously obstructed frontier points.

The exploration now finishes if either all points are explored, or the frontier list only contains blacklisted points.

---

### Implementation details / comments

- This introduces 2 new parameters for the bounded explore layer: the global frame (`global_frame`, default `"map"`) and the blacklist radius (`blacklist_radius`, default 1.0).
- Two new services are introduced for the bounded explore layer: `blacklist_point` (`frontier_exploration::BlacklistPoint`) and `clear_blacklist` (`std_srvs::Empty`)
- The `Frontier` message now only contains a single travel point, depending on the chosen value for `frontier_travel_point`.
- The value `frontier_travel_point` is now used in `FrontierSearch::buildNewFrontier` rather than the explore layer.
- The blacklist is visualized in `rviz` by using `visualization_msgs::Marker` cilinders with small height. Screenshot of blacklisted exploration points:
![blacklist](https://cloud.githubusercontent.com/assets/1073881/24899687/75c4da7e-1ea1-11e7-82d4-3fa986410eb5.png)
