### PR TITLE
Initial ROS2 Port

### DIFF
--- a/polygon_layer/src/polygon_layer.cpp
+++ b/polygon_layer/src/polygon_layer.cpp
@@ -157,10 +157,10 @@ void PolygonLayer::updateBounds(double robot_x, double robot_y, double robot_yaw
   if (!activated_ || !enabled_ || polygon_.polygon.points.empty())
   { return; }
 
-  *min_x = min_x_;
-  *min_y = min_y_;
-  *max_x = max_x_;
-  *max_y = max_y_;
+  *min_x = std::min(*min_x, min_x_);
+  *min_y = std::min(*min_y, min_y_);
+  *max_x = std::max(*max_x, max_x_);
+  *max_y = std::max(*max_y, max_y_);
   MarkCell marker(costmap_, LETHAL_OBSTACLE);
   for (unsigned int i = 0, j = polygon_.polygon.points.size()-1; i < polygon_.polygon.points.size(); j = i++)
   {


### PR DESCRIPTION
Apart from the full Port to ROS2, A simple publisher is added at the end which subscribes to the "map" topic and publishes the frontier centroid and intial points. I made this change for an initial demo. I will remove this once the costmap plugin is ported.
The overflow update bounds in the costmap is fixed as well.

Please do have a look when you have time :)